### PR TITLE
plot_birefringence speedup

### DIFF
--- a/utils/plotting.py
+++ b/utils/plotting.py
@@ -45,60 +45,97 @@ def plotVectorField(I, azimuth, R=40, spacing=40, clim=[None, None]): # plot vec
     return imAx
 
 def plot_birefringence(imgInput, imgs, outputChann, spacing=20, vectorScl=5, zoomin=False, dpi=300, norm=True, plot=True):
-    I_trans,retard, azimuth, polarization, ImgFluor = imgs
-    scattering = 1-polarization
-    tIdx = imgInput.tIdx
-    zIdx = imgInput.zIdx
-    posIdx = imgInput.posIdx
-    # chann_scale = [10, 10, 10, 10] # scale fluor channels for composite images when norm=False
     chann_scale = [0.25, 1, 0.05, 1]  # scale fluor channels for composite images when norm=False
+    
+    I_trans,retard, azimuth, polarization, ImgFluor = imgs
     if zoomin: # crop the images
         imList = [I_trans, retard, azimuth]
-        imListCrop = imcrop(imList, I_trans)
-        I_trans,retard, azimuth = imListCrop
-
+        I_trans,retard, azimuth = imcrop(imList, I_trans)
     azimuth_degree = azimuth/np.pi*180
-    I_azi_ret_trans, I_azi_ret, I_azi_scat = PolColor(I_trans, retard, azimuth_degree, scattering, norm=norm)
-    azimuth_x = np.cos(2 * azimuth)
-    azimuth_y = np.sin(2 * azimuth)
-    if plot:
-        plot_recon_images(I_trans, retard, azimuth, scattering, I_azi_ret, I_azi_scat, zoomin=False, spacing=spacing,
-                          vectorScl=vectorScl, dpi=dpi)
-        if zoomin:
-            figName = 'Transmission+Retardance+Orientation_Zoomin.jpg'
+    scattering = 1-polarization
+    
+    # Compute Retardance+Orientation, Scattering+Orientation, and Transmission+Retardance+Orientation overlays
+    # Slow, results in large files
+    # Optionally, plot results in tiled image
+    if any(chann in ['Retardance+Orientation', 'Scattering+Orientation', 'Transmission+Retardance+Orientation']
+            for chann in outputChann):
+        I_azi_ret_trans, I_azi_ret, I_azi_scat = PolColor(I_trans, retard, azimuth_degree, scattering, norm=norm)
+        
+        tIdx = imgInput.tIdx; zIdx = imgInput.zIdx; posIdx = imgInput.posIdx
+        if plot:
+            plot_recon_images(I_trans, retard, azimuth, scattering, I_azi_ret, I_azi_scat, zoomin=False, spacing=spacing,
+                              vectorScl=vectorScl, dpi=dpi)
+            if zoomin:
+                figName = 'Transmission+Retardance+Orientation_Zoomin.jpg'
+            else:
+                figName = 'Transmission+Retardance+Orientation_t%03d_p%03d_z%03d.jpg' % (tIdx, posIdx, zIdx)
+    
+            plt.savefig(os.path.join(imgInput.ImgOutPath, figName), dpi=dpi, bbox_inches='tight')
+     
+    # Compute Retardance+Fluorescence and Retardance+Fluorescence_all overlays
+    # Very slow
+    if any(chann in ['Retardance+Fluorescence', 'Retardance+Fluorescence_all'] for chann in outputChann):
+        IFluorRetard = CompositeImg([100*retard, ImgFluor[2,:,:]*chann_scale[2], ImgFluor[0,:,:]*chann_scale[0]], norm=norm)
+        I_fluor_all_retard = CompositeImg([100 * retard,
+                                           ImgFluor[3, :, :] * chann_scale[3],
+                                           ImgFluor[2, :, :] * chann_scale[2],
+                                           ImgFluor[1, :, :] * chann_scale[1],
+                                           ImgFluor[0, :, :] * chann_scale[0]], norm=norm)
+    
+    imgDict = {}
+    for chann in outputChann:
+        if chann == 'Transmission':
+            img = imBitConvert(I_trans * 10 ** 4, bit=16, norm=False)  # AU, set norm to False for tiling images
+            
+        elif chann == 'Retardance':
+            img = imBitConvert(retard * 10 ** 3, bit=16)  # scale to pm
+            
+        elif chann == 'Orientation':
+            img = imBitConvert(azimuth_degree * 100, bit=16)  # scale to [0, 18000], 100*degree
+            
+        elif chann == 'Scattering':
+            img = imBitConvert(scattering * 10 ** 6, bit=16)
+        
+        elif chann == 'Orientation_x':
+            azimuth_x = np.cos(2 * azimuth)
+            img = imBitConvert((azimuth_x+1) * 1000, bit=16) # scale to [0, 1000]
+        
+        elif chann == 'Orientation_y':
+            azimuth_y = np.sin(2 * azimuth)
+            img = imBitConvert((azimuth_y+1) * 1000, bit=16)  # scale to [0, 1000]
+        elif chann == 'Retardance+Orientation':
+            img = I_azi_ret
+            
+        elif chann == 'Scattering+Orientation':
+            img = I_azi_scat
+            
+        elif chann == 'Transmission+Retardance+Orientation':
+            img = I_azi_ret_trans
+            
+        elif chann == '405':
+            img = imBitConvert(ImgFluor[0,:,:], bit=16, norm=False)
+                    
+        elif chann == '488':
+            img = imBitConvert(ImgFluor[1,:,:], bit=16, norm=False)
+                        
+        elif chann == '568':
+            img = imBitConvert(ImgFluor[2,:,:], bit=16, norm=False)
+                        
+        elif chann == '640':
+            img = imBitConvert(ImgFluor[3,:,:], bit=16, norm=False)
+            
+        elif chann == 'Retardance+Fluorescence':
+            img = IFluorRetard
+            
+        elif chann == 'Retardance+Fluorescence_all':
+            img = I_fluor_all_retard
+            
         else:
-            figName = 'Transmission+Retardance+Orientation_t%03d_p%03d_z%03d.jpg' % (tIdx, posIdx, zIdx)
-
-        plt.savefig(os.path.join(imgInput.ImgOutPath, figName), dpi=dpi, bbox_inches='tight')
-
-    IFluorRetard = CompositeImg([100*retard, ImgFluor[2,:,:]*chann_scale[2], ImgFluor[0,:,:]*chann_scale[0]], norm=norm)
-    # I_fluor_all_retard = CompositeImg([100 * retard, ImgFluor[1, :, :] * 0.05, ImgFluor[0, :, :] * 0.05], norm=norm)
-    I_fluor_all_retard = CompositeImg([100 * retard,
-                                       ImgFluor[3, :, :] * chann_scale[3],
-                                       ImgFluor[2, :, :] * chann_scale[2],
-                                       ImgFluor[1, :, :] * chann_scale[1],
-                                       ImgFluor[0, :, :] * chann_scale[0]], norm=norm)
-#    images = [I_trans, retard, azimuth_degree, I_azi_ret, I_azi_ret_trans, IFluorRetard]
-    I_trans = imBitConvert(I_trans * 10 ** 4, bit=16, norm=False)  # AU, set norm to False for tiling images
-#     I_trans = imBitConvert(I_trans * 10 ** 0, bit=16, norm=False)  # AU, set norm to False for tiling images
-    retard = imBitConvert(retard * 10 ** 3, bit=16)  # scale to pm
-    scattering = imBitConvert(scattering * 10 ** 6, bit=16)
-    azimuth_degree = imBitConvert(azimuth_degree * 100, bit=16)  # scale to [0, 18000], 100*degree
-    azimuth_x = imBitConvert((azimuth_x+1) * 1000, bit=16) # scale to [0, 1000]
-    azimuth_y = imBitConvert((azimuth_y+1) * 1000, bit=16)  # scale to [0, 1000]
-    imagesTrans = [I_trans, retard, azimuth_degree, scattering,
-                   azimuth_x, azimuth_y, I_azi_ret, I_azi_scat, I_azi_ret_trans] #trasmission channels
-    imagesFluor = [imBitConvert(ImgFluor[i,:,:], bit=16, norm=False) for i in range(ImgFluor.shape[0])]+[IFluorRetard, I_fluor_all_retard]
-
-    images = imagesTrans+imagesFluor
-    chNames = ['Transmission', 'Retardance', 'Orientation', 'Scattering',
-               'Orientation_x', 'Orientation_y',
-                            'Retardance+Orientation', 'Scattering+Orientation',
-               'Transmission+Retardance+Orientation',
-                            '405','488','568','640', 'Retardance+Fluorescence',
-               'Retardance+Fluorescence_all']
-
-    imgDict = dict(zip(chNames, images))
+            # TODO: write error handling
+            continue
+            
+        imgDict[chann] = img
+        
     imgInput.chNames = outputChann
     imgInput.nChann = len(outputChann)
     return imgInput, imgDict


### PR DESCRIPTION
plot_birefringence generates all output channels even if they are not requested. Rewrote to process data only if needed. Results in 2-3x speedup if only a minimal set of channels is requested (e.g. 'Transmission', 'Retardance', 'Orientation', 'Scattering').