### PR TITLE
Phase from defocus

### DIFF
--- a/ReconstructOrder/datastructures/create_intensity_data.py
+++ b/ReconstructOrder/datastructures/create_intensity_data.py
@@ -115,7 +115,7 @@ class IntensityDataCreator(object):
                 imgs.replace_image(img, '640')
             elif any(substring in chan_name for substring in ['FM464', 'fm464']):
                 imgs.replace_image(img, 'ex561em700')
-        elif any(substring in chan_name for substring in ['BF', 'BrightField']):
+        elif any(substring in chan_name for substring in ['BF', 'BrightField', 'Default']):
             imgs.replace_image(img, 'BF')
 
         return imgs

--- a/ReconstructOrder/utils/ConfigReader.py
+++ b/ReconstructOrder/utils/ConfigReader.py
@@ -204,6 +204,8 @@ class ConfigReader:
                     self.plotting.transmission_scaling = float(value)
                 elif key == 'phase_2D_scaling':
                     self.plotting.phase_2D_scaling = float(value)
+                elif key == 'absorption_2D_scaling':
+                    self.plotting.absorption_2D_scaling = float(value)
                 elif key == 'phase_3D_scaling':
                     self.plotting.phase_3D_scaling = float(value)
                 elif key == 'save_birefringence_fig':
@@ -382,8 +384,9 @@ class Dataset:
 
 
 class Processing:
-    _allowed_output_channels = ['Brightfield', 'Brightfield_computed', 'Retardance', 'Orientation', 'Polarization',
+    _allowed_output_channels = ['Brightfield', 'Brightfield_computed', 'Retardance', 'Orientation', 'Polarization', 'RetardanceZavg', 'OrientationZavg',
                                 'Phase2D', 'Phase_semi3D', 'Phase3D',
+                                'Absorption2D', 'Absorption_semi3D',
                                 'Orientation_x', 'Orientation_y',
                                 'Pol_State_0', 'Pol_State_1', 'Pol_State_2', 'Pol_State_3', 'Pol_State_4',
                                 'Stokes_0', 'Stokes_1', 'Stokes_2', 'Stokes_3',
@@ -746,6 +749,7 @@ class Plotting:
         self.transmission_scaling   = 1E4
         self.retardance_scaling     = 1E3
         self.phase_2D_scaling       = 1
+        self.absorption_2D_scaling  = 1
         self.phase_3D_scaling       = 1
         self.save_birefringence_fig = False
         self.save_stokes_fig        = False

--- a/ReconstructOrder/workflow/multiDimProcess.py
+++ b/ReconstructOrder/workflow/multiDimProcess.py
@@ -13,7 +13,7 @@ from ..compute.reconstruct_phase import phase_reconstructor
 from ..utils.imgProcessing import im_bit_convert
 from ..utils.plotting import render_birefringence_imgs, plot_stokes, plot_pol_imgs
 from ..utils.mManagerIO import mManagerReader, PolAcquReader
-from ..datastructures import StokesData, IntensityDataCreator, IntensityData
+from ..datastructures import StokesData, IntensityDataCreator, IntensityData, PhysicalData
 from ..utils.ConfigReader import ConfigReader
 from ..utils.flat_field import FlatFieldCorrector
 from ..utils.aux_utils import loop_pt
@@ -329,23 +329,32 @@ def process_sample_imgs(img_io: Union[mManagerReader, PolAcquReader]=None,
                        'Retardance+Orientation', 'Polarization+Orientation', 'Brightfield+Retardance+Orientation',
                        'Brightfield_computed+Retardance+Orientation',
                        'Retardance+Fluorescence', 'Retardance+Fluorescence_all']
-    phase_names     = ['Phase2D', 'Phase_semi3D', 'Phase3D']
+    ret_Zavg_names  = ['RetardanceZavg', 'OrientationZavg']
+    phase_names     = ['Phase2D', 'Phase_semi3D', 'Phase3D', 'Absorption2D', 'Absorption_semi3D']
     fluor_names     = ['405', '488', '568', '640', 'ex561em700']
+
 
     # 2 )set flags based on names defined in 1)
     save_stokes    = any(chan in stokes_names + stokes_names_sm for chan in img_io.output_chans) \
-                     or save_stokes_fig
+                 or save_stokes_fig
     save_phase     = any(chan in phase_names for chan in img_io.output_chans)
-    save_birefring = any(chan in birefring_names for chan in img_io.output_chans) or save_fig or save_phase
+    save_ret_Zavg  = any(chan in img_io.output_chans for chan in ret_Zavg_names)
+    save_birefring = any(chan in birefring_names for chan in img_io.output_chans) or save_fig or save_phase or save_ret_Zavg
     save_BF        = 'Brightfield' in img_io.output_chans
     save_pol       = any(chan in pol_names for chan in img_io.output_chans) or save_pol_fig
     save_fluor     = any(chan in fluor_names for chan in img_io.output_chans)
+
+    have_pol_data = any([any([substring in chan_name for substring in ['State', 'state', 'Pol']])\
+                         for chan_name in img_io.input_chans])
+    if not have_pol_data:
+        save_birefring = False
 
     print('Processing position %03d, time %03d ... (t=0 min)' % (pos_idx, t_idx))
     start_time=time.time()
     for z_stack_idx in range(0, len(z_list), n_slice_local_bg):
         stokes_param_sm_stack = [[] for i in range(len(stokes_names))]
         fluor_stack_list = []
+        BF_stack = []
 
         for z_list_idx in range(z_stack_idx, z_stack_idx + n_slice_local_bg):
             z_idx = z_list[z_list_idx]
@@ -365,6 +374,8 @@ def process_sample_imgs(img_io: Union[mManagerReader, PolAcquReader]=None,
                     stack.append(img)
                 # retard = removeBubbles(retard)     # remove bright speckles in mounted brain slice images
             img_bf = img_int_sm.get_image('BF')
+            if save_phase and not have_pol_data:
+                BF_stack.append(img_bf)
             if save_BF and isinstance(img_bf, np.ndarray):
                 img_bf = img_bf / stokes_bg.s0  # flat-field correction
                 img_bf = im_bit_convert(img_bf * config.plotting.transmission_scaling, bit=16, norm=False)
@@ -401,6 +412,18 @@ def process_sample_imgs(img_io: Union[mManagerReader, PolAcquReader]=None,
             if img_io.bg_correct:
                 norm_sample = img_reconstructor.correct_background(norm_sample, stokes_bg)
 
+            if save_ret_Zavg:
+                stk_attribute_name = ['s0', 's1_norm', 's2_norm', 's3', 'polarization']
+                norm_sample_Zavg = StokesData()
+                [norm_sample_Zavg.s0,
+                 norm_sample_Zavg.s1_norm,
+                 norm_sample_Zavg.s2_norm,
+                 norm_sample_Zavg.s3,
+                 norm_sample_Zavg.polarization] = [np.mean(stack, axis=2) for stack in
+                                                  [norm_sample.__getattribute__(stack_name) for stack_name in stk_attribute_name]]
+
+                physical_data_Zavg = img_reconstructor.reconstruct_birefringence(norm_sample_Zavg)
+
             elapsed_time=(time.time()-start_time)/60
             print('Reconstructing retardance and orientation (t=%3.2f min)' % elapsed_time)
 
@@ -408,34 +431,6 @@ def process_sample_imgs(img_io: Union[mManagerReader, PolAcquReader]=None,
 
             elapsed_time=(time.time()-start_time)/60
             print('Finished reconstructing retardance and orientation (t=%3.2f min)' % elapsed_time)
-
-            if ph_recon:
-                for deconv_dim in ph_recon.phase_deconv:
-                    
-                    if deconv_dim == '2D':
-                        elapsed_time = (time.time() - start_time) / 60
-                        print('Reconstructing 2D phase (t=%3.2f min)' % elapsed_time)
-
-                        physical_data.absorption_2D, physical_data.phase_2D = ph_recon.Phase_recon_2D(norm_sample)
-
-                        elapsed_time = (time.time() - start_time) / 60
-                        print('Finished reconstructing 2D phase (t=%3.2f min)' % elapsed_time)
-                    if deconv_dim == 'semi-3D':
-                        elapsed_time = (time.time() - start_time) / 60
-                        print('Reconstructing semi-3D phase (t=%3.2f min)' % elapsed_time)
-
-                        physical_data.absorption_semi3D, physical_data.phase_semi3D = ph_recon.Phase_recon_semi_3D(norm_sample)
-
-                        elapsed_time = (time.time() - start_time) / 60
-                        print('Finished reconstructing semi-3D phase (t=%3.2f min)' % elapsed_time)
-                    if deconv_dim == '3D':
-                        elapsed_time = (time.time() - start_time) / 60
-                        print('Reconstructing 3D phase (t=%3.2f min)' % elapsed_time)
-
-                        physical_data.phase_3D = ph_recon.Phase_recon_3D(norm_sample)
-
-                        elapsed_time = (time.time() - start_time) / 60
-                        print('Finished reconstructing 3D phase (t=%3.2f min)' % elapsed_time)
 
 
             img_dict = {}
@@ -461,18 +456,7 @@ def process_sample_imgs(img_io: Union[mManagerReader, PolAcquReader]=None,
                     img_io, img_dict = render_birefringence_imgs(img_io, imgs, config, spacing=20, vectorScl=8, zoomin=False,
                                                                  dpi=200,
                                                                  norm=norm, plot=save_fig)
-                if save_phase:
-                    for channel in list(set(phase_names) & set(img_io.output_chans)):
-                        if ph_recon.focus_idx == z_sub_idx and channel == 'Phase2D':
-                            img = im_bit_convert(physical_data.phase_2D * config.plotting.phase_2D_scaling, bit=16, norm=True, limit=[-5, 5])
-                            img_dict[channel] = img.copy()
-                        elif channel == 'Phase_semi3D':
-                            img = im_bit_convert(physical_data.phase_semi3D[..., z_sub_idx] * config.plotting.phase_2D_scaling, bit=16, norm=True, limit=[-5, 5])
-                            img_dict[channel] = img.copy()
-                        elif channel == 'Phase3D':
-                            img = im_bit_convert(physical_data.phase_3D[..., z_sub_idx] * config.plotting.phase_3D_scaling, bit=16, norm=True, limit=[-5, 5])
-                            img_dict[channel] = img.copy()
-                        
+
                 if save_stokes:
                     img_stokes = [s0, s1, s2, s3]
                     img_stokes_sm = [stack[..., z_sub_idx] for stack in norm_sample.data]
@@ -488,8 +472,88 @@ def process_sample_imgs(img_io: Union[mManagerReader, PolAcquReader]=None,
 
                 export_img(img_io, img_dict, separate_pos)
 
-            elapsed_time=time.time()-start_time
-            print('Finish processing and exporting (t=%3.2f min)' % elapsed_time)
+            if save_ret_Zavg:
+                plt.close("all")  # close all the figures from the last run
+                img_io.z_idx = z_list[0]
+                img_dict = {}
+                retard   = physical_data_Zavg.retard
+                azimuth  = physical_data_Zavg.azimuth
+                for channel in list(set(ret_Zavg_names) & set(img_io.output_chans)):
+                    if channel == 'RetardanceZavg':
+                        img = im_bit_convert(retard * config.plotting.retardance_scaling, bit=16)
+                        img_dict[channel] = img.copy()
+                    elif channel == 'OrientationZavg':
+                        azimuth_degree = azimuth/np.pi*180
+                        img = im_bit_convert(azimuth_degree * 100, bit=16)
+                        img_dict[channel] = img.copy()
+                export_img(img_io, img_dict, separate_pos)
+
+
+            elapsed_time=(time.time()-start_time) / 60
+            print('Finish exporting birefringent reconstruction (t=%3.2f min)' % elapsed_time)
+
+        if save_phase:
+
+            if not have_pol_data:            
+                norm_sample = StokesData()
+                norm_sample.s0 = np.stack(BF_stack, axis=-1)
+                physical_data = PhysicalData()
+            for deconv_dim in ph_recon.phase_deconv:
+
+                if deconv_dim == '2D':
+                    elapsed_time = (time.time() - start_time) / 60
+                    print('Reconstructing 2D phase (t=%3.2f min)' % elapsed_time)
+
+                    physical_data.absorption_2D, physical_data.phase_2D = ph_recon.Phase_recon_2D(norm_sample)
+
+                    elapsed_time = (time.time() - start_time) / 60
+                    print('Finished reconstructing 2D phase (t=%3.2f min)' % elapsed_time)
+                if deconv_dim == 'semi-3D':
+                    elapsed_time = (time.time() - start_time) / 60
+                    print('Reconstructing semi-3D phase (t=%3.2f min)' % elapsed_time)
+
+                    physical_data.absorption_semi3D, physical_data.phase_semi3D = ph_recon.Phase_recon_semi_3D(norm_sample)
+
+                    elapsed_time = (time.time() - start_time) / 60
+                    print('Finished reconstructing semi-3D phase (t=%3.2f min)' % elapsed_time)
+                if deconv_dim == '3D':
+                    elapsed_time = (time.time() - start_time) / 60
+                    print('Reconstructing 3D phase (t=%3.2f min)' % elapsed_time)
+
+                    physical_data.phase_3D = ph_recon.Phase_recon_3D(norm_sample)
+
+                    elapsed_time = (time.time() - start_time) / 60
+                    print('Finished reconstructing 3D phase (t=%3.2f min)' % elapsed_time)
+
+
+            for z_idx in range(z_stack_idx, z_stack_idx + n_slice_local_bg):
+                plt.close("all")  # close all the figures from the last run
+                img_io.z_idx = z_list[z_idx]
+                z_sub_idx = z_idx - z_stack_idx
+
+                img_dict = {}
+                for channel in list(set(phase_names) & set(img_io.output_chans)):
+                    if ph_recon.focus_idx == z_sub_idx and channel == 'Phase2D':
+                        img = im_bit_convert(physical_data.phase_2D * config.plotting.phase_2D_scaling, bit=16, norm=True, limit=[-5, 5])
+                        img_dict[channel] = img.copy()
+                    elif ph_recon.focus_idx == z_sub_idx and channel == 'Absorption2D':
+                        img = im_bit_convert(physical_data.absorption_2D * config.plotting.absorption_2D_scaling, bit=16, norm=True, limit=[-1, 1])
+                        img_dict[channel] = img.copy()
+                    elif channel == 'Phase_semi3D':
+                        img = im_bit_convert(physical_data.phase_semi3D[..., z_sub_idx] * config.plotting.phase_2D_scaling, bit=16, norm=True, limit=[-5, 5])
+                        img_dict[channel] = img.copy()
+                    elif channel == 'Absorption_semi3D':
+                        img = im_bit_convert(physical_data.absorption_semi3D[..., z_sub_idx] * config.plotting.absorption_2D_scaling, bit=16, norm=True, limit=[-1, 1])
+                        img_dict[channel] = img.copy()
+                    elif channel == 'Phase3D':
+                        img = im_bit_convert(physical_data.phase_3D[..., z_sub_idx] * config.plotting.phase_3D_scaling, bit=16, norm=True, limit=[-5, 5])
+                        img_dict[channel] = img.copy()
+
+                export_img(img_io, img_dict, separate_pos)
+
+
+        elapsed_time=(time.time()-start_time) / 60
+        print('Finish processing and exporting all reconstructions (t=%3.2f min)' % elapsed_time)
 
 
 

--- a/examples/config_example.yml
+++ b/examples/config_example.yml
@@ -49,7 +49,7 @@ processing:
 
   # (list) Any combination of the following values.
   ##    'Brightfield', 'Brightfield_computed', 'Retardance', 'Orientation', 'Polarization',
-  ##    'Orientation_x', 'Orientation_y', 'Phase2D', 'Phase3D',
+  ##    'Orientation_x', 'Orientation_y', 'Phase2D', 'Absorption2D', 'Phase3D',
   ##    'Pol_State_0', 'Pol_State_1', 'Pol_State_2', 'Pol_State_3', 'Pol_State_4',
   ##    'Stokes_0', 'Stokes_1', 'Stokes_2', 'Stokes_3',
   ##    '405', '488', '568', '640', 'ex561em700'
@@ -203,6 +203,10 @@ plotting:
   phase_2D_scaling: 1  
   # (float) scaling factor of 2D phase images
   ##   when scaling is 1, phase is plotted from -5 to 5 radian
+  
+  absorption_2D_scaling: 1  
+  # (float) scaling factor of 2D absorption images
+  ##   when scaling is 1, absorption is plotted from -1 to 1
   
   phase_3D_scaling: 1  
   # (float) scaling factor of 3D phase images

--- a/examples/config_example.yml
+++ b/examples/config_example.yml
@@ -49,6 +49,7 @@ processing:
 
   # (list) Any combination of the following values.
   ##    'Brightfield', 'Brightfield_computed', 'Retardance', 'Orientation', 'Polarization',
+  ##    'RetardanceZavg', 'OrientationZavg',
   ##    'Orientation_x', 'Orientation_y', 'Phase2D', 'Absorption2D', 'Phase3D',
   ##    'Pol_State_0', 'Pol_State_1', 'Pol_State_2', 'Pol_State_3', 'Pol_State_4',
   ##    'Stokes_0', 'Stokes_1', 'Stokes_2', 'Stokes_3',


### PR DESCRIPTION
This PR includes the following update:

1. Enable 2D phase and 3D phase reconstruction from only brightfield defocused intensity measurement. Right now, the program recognizes "Default", "Brightfield", and "BF" as the channel name for brightfield measurements in MM acquisition. It will only use brightfield data when the program does not find Polscope acquisition but still is asked to output phase.

2. Enable the output of a deconvolved 2D absorption image (~deconvolved brightfield) by adding a string "Absorption2D" in the output channel field of a config file. This is the result coming out from 2D phase reconstruction.

3. Enable the output of z-average retardance and orientation by adding "RetardanceZavg" and "OrientationZavg" in the output channel field of a config file. This is implemented by taking the average of the background-subtracted Stokes parameters over z-axis and computing retardance and orientation out of it.

I have tested this PR with Janie's new data and our example datasets. It runs well. Please let me know places to modify for better performance and clarity. Thanks.